### PR TITLE
add `BANG` char to lexer

### DIFF
--- a/src/language/src/lexer.mll
+++ b/src/language/src/lexer.mll
@@ -62,6 +62,7 @@ rule read =
   | '['         { LEFT_BRACK }
   | ']'         { RIGHT_BRACK }
   | ':'         { COLON }
+  | '!'         { BANG }
   | ','         { read lexbuf }
   | _           { raise (SyntaxError ("Unexpected char: " ^ Lexing.lexeme lexbuf)) }
   | eof         { EOF }

--- a/src/language/test/assets/query_5.graphql
+++ b/src/language/test/assets/query_5.graphql
@@ -1,0 +1,7 @@
+query getZuckProfile($devicePicSize: Int!) {
+  user(id: 4) {
+    id
+    name
+    profilePic(size: $devicePicSize)
+  }
+}


### PR DESCRIPTION
`!` char is missing in lexer
Thus the following query cannot be parsed.

```
query getZuckProfile($devicePicSize: Int!) {
  user(id: 4) {
    id
    name
    profilePic(size: $devicePicSize)
  }
}
```
